### PR TITLE
[WIP] Add requirements for EAT partial profile

### DIFF
--- a/draft-moriarty-rats-posture-assessment.md
+++ b/draft-moriarty-rats-posture-assessment.md
@@ -62,7 +62,7 @@ informative:
 --- abstract
 
 This document establishes an architectural pattern whereby a remote attestation could be issued for a complete set of benchmarks or controls that are defined and grouped by an external entity, preventing the need to send over individual attestations for each item within a benchmark or control framework.
-This document establishes a pattern to list sets of benchmarks and controls within CWT and JWT formats for use as an Entity Attestation Token (EAT).
+This document establishes a pattern to list sets of benchmarks and controls within CWT and JWT formats for use as an Entity Attestation Token (EAT) partial profile.
 
 --- middle
 


### PR DESCRIPTION
Upon re-reading of the [I-D.draft-ietf-rats-eat](https://datatracker.ietf.org/doc/html/draft-ietf-rats-eat-28#name-profiles) around profiling requirements, we may want to clarify some of the recommended information per that I-D that should be in her given the profiled usage of EAT.

@KME this will be a work in progress until I remove the WIP and draft labels off the PR, but if you approve of it once it is better shape later in the afternoon, it is up to you if we merge it or not. We can discuss via email.