### PR TITLE
Switch from Product to Target Environment

### DIFF
--- a/draft-moriarty-rats-posture-assessment.md
+++ b/draft-moriarty-rats-posture-assessment.md
@@ -140,13 +140,13 @@ The trustworthiness will be conveyed on original verified evidence as well as th
 
 # Supportability and Re-Attestation
 
-The remote attestation framework shall include provisions within the system and attestation authority to allow for Product modification.
+The remote attestation framework shall include provisions for a Verifier Owner and Relying Party Owner to declare an Appraisal Policy for Attestation Results and Evidence that allows for modification of the Target Environment (e.g. a product, system, or service).
 
-Over its lifecycle, the Product may experience modification due to: maintenance, failures, upgrades, expansion, moves, etc..
+Over its lifecycle, the Target Environment may experience modification due to: maintenance, failures, upgrades, expansion, moves, etc..
 
 The customer can chose to:
 
-- Run remote attestation after product modification, or
+- Run remote attestation after Target Environment modification, or
 - Not take action and remain un-protected
 
 In the case of Re-Attestation:


### PR DESCRIPTION
I do find the explanation of Product approachable, but it is not a formally defined term in RFC9334 and is disjoint with the way RATS WG formally describes the entity and related roles. I would think we might want to consider this phrasing.

Note, I am drafting an email with other information about re-attestation and supportability re email, the next PR will propose other rewrites separate of Product->TE, but this is a specific change I thought worth reviewing separate of that.